### PR TITLE
Added gapless playback functionality

### DIFF
--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -1,15 +1,15 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 include ':app'
 
-def localPropertiesFile = new File(rootProject.projectDir, "local.properties")
-def properties = new Properties()
+def flutterProjectRoot = rootProject.projectDir.parentFile.toPath()
 
-assert localPropertiesFile.exists()
-localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
+def plugins = new Properties()
+def pluginsFile = new File(flutterProjectRoot.toFile(), '.flutter-plugins')
+if (pluginsFile.exists()) {
+    pluginsFile.withReader('UTF-8') { reader -> plugins.load(reader) }
+}
 
-def flutterSdkPath = properties.getProperty("flutter.sdk")
-assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
-apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+plugins.each { name, path ->
+    def pluginDirectory = flutterProjectRoot.resolve(path).resolve('android').toFile()
+    include ":$name"
+    project(":$name").projectDir = pluginDirectory
+}

--- a/lib/src/image.dart
+++ b/lib/src/image.dart
@@ -148,6 +148,10 @@ class OctoImage extends StatefulWidget {
   /// If not given a value, defaults to FilterQuality.low.
   final FilterQuality filterQuality;
 
+  /// Whether to continue showing the old image (true), or briefly show the
+  /// placeholder (false), when the image provider changes.
+  final bool gaplessPlayback;
+
   /// Creates an OctoWidget that displays an image. The [image] is an
   /// ImageProvider and the OctoImage should work with any [ImageProvider].
   /// The widget is optimized for [CachedNetworkImageProvider](https://pub.dev/packages/cached_network_image) or
@@ -205,6 +209,7 @@ class OctoImage extends StatefulWidget {
     this.filterQuality = FilterQuality.low,
     this.colorBlendMode,
     this.placeholderFadeInDuration = Duration.zero,
+    this.gaplessPlayback = false,
     int memCacheWidth,
     int memCacheHeight,
   })  : image = ResizeImage.resizeIfNeeded(
@@ -270,6 +275,7 @@ class OctoImage extends StatefulWidget {
     this.filterQuality = FilterQuality.low,
     this.colorBlendMode,
     this.placeholderFadeInDuration = Duration.zero,
+    this.gaplessPlayback = false,
     int memCacheWidth,
     int memCacheHeight,
   })  : image = ResizeImage.resizeIfNeeded(
@@ -297,6 +303,17 @@ class OctoImage extends StatefulWidget {
 }
 
 class _OctoImageState extends State<OctoImage> {
+  bool _isImageResolved = false;
+
+  @override
+  void didUpdateWidget(OctoImage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if(!widget.gaplessPlayback && oldWidget.image != widget.image){
+      _isImageResolved = false;
+    }
+    super.didChangeDependencies();
+  }
+
   @override
   Widget build(BuildContext context) {
     var placeholderType = _definePlaceholderType();
@@ -329,6 +346,7 @@ class _OctoImageState extends State<OctoImage> {
       colorBlendMode: widget.colorBlendMode,
       matchTextDirection: widget.matchTextDirection,
       filterQuality: widget.filterQuality,
+      gaplessPlayback: widget.gaplessPlayback,
     );
   }
 
@@ -415,6 +433,7 @@ class _OctoImageState extends State<OctoImage> {
   }
 
   Widget _image(BuildContext context, Widget child) {
+    _isImageResolved = true;
     if (widget.imageBuilder != null) {
       return widget.imageBuilder(context, child);
     }
@@ -443,6 +462,8 @@ class _OctoImageState extends State<OctoImage> {
   _PlaceholderType _definePlaceholderType() {
     assert(widget.placeholderBuilder == null ||
         widget.progressIndicatorBuilder == null);
+
+    if(_isImageResolved) return _PlaceholderType.none;
 
     if (widget.placeholderBuilder != null) return _PlaceholderType.static;
     if (widget.progressIndicatorBuilder != null) {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
feature

### :arrow_heading_down: What is the current behavior?
OctoImage doesn't support gapless playback, a basic feature of Image.

### :new: What is the new behavior (if this is a feature change)?
OctoImage now supports gapless playback, it keeps showing the old image when a new image is being loaded instead of switching to a placeholder.

### :boom: Does this PR introduce a breaking change?
No, default value is `false`

### :memo: Links to relevant issues/docs
https://api.flutter.dev/flutter/widgets/Image/gaplessPlayback.html

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines 
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
