### PR TITLE
Made custom gapless playback with fade

### DIFF
--- a/lib/src/image.dart
+++ b/lib/src/image.dart
@@ -308,8 +308,8 @@ class _OctoImageState extends State<OctoImage> {
   @override
   void didUpdateWidget(OctoImage oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if(oldWidget.image != widget.image){
-      if(widget.gaplessPlayback && _resolvedImage != null){
+    if (oldWidget.image != widget.image) {
+      if (widget.gaplessPlayback && _resolvedImage != null) {
         _previousImage = _resolvedImage;
       }
       _resolvedImage = null;
@@ -436,7 +436,7 @@ class _OctoImageState extends State<OctoImage> {
   Widget _image(BuildContext context, Widget child) {
     if (widget.imageBuilder != null) {
       _resolvedImage = widget.imageBuilder(context, child);
-    }else{
+    } else {
       _resolvedImage = child;
     }
     return _resolvedImage;
@@ -455,7 +455,7 @@ class _OctoImageState extends State<OctoImage> {
   }
 
   Widget _placeholder(BuildContext context) {
-    if(_previousImage != null) return _previousImage;
+    if (_previousImage != null) return _previousImage;
 
     if (widget.placeholderBuilder != null) {
       return Center(child: widget.placeholderBuilder(context));

--- a/lib/src/image.dart
+++ b/lib/src/image.dart
@@ -302,13 +302,17 @@ class OctoImage extends StatefulWidget {
 }
 
 class _OctoImageState extends State<OctoImage> {
-  bool _isImageResolved = false;
+  Widget _previousImage;
+  Widget _resolvedImage;
 
   @override
   void didUpdateWidget(OctoImage oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (!widget.gaplessPlayback && oldWidget.image != widget.image) {
-      _isImageResolved = false;
+    if(oldWidget.image != widget.image){
+      if(widget.gaplessPlayback && _resolvedImage != null){
+        _previousImage = _resolvedImage;
+      }
+      _resolvedImage = null;
     }
   }
 
@@ -344,7 +348,6 @@ class _OctoImageState extends State<OctoImage> {
       colorBlendMode: widget.colorBlendMode,
       matchTextDirection: widget.matchTextDirection,
       filterQuality: widget.filterQuality,
-      gaplessPlayback: widget.gaplessPlayback,
     );
   }
 
@@ -431,11 +434,12 @@ class _OctoImageState extends State<OctoImage> {
   }
 
   Widget _image(BuildContext context, Widget child) {
-    _isImageResolved = true;
     if (widget.imageBuilder != null) {
-      return widget.imageBuilder(context, child);
+      _resolvedImage = widget.imageBuilder(context, child);
+    }else{
+      _resolvedImage = child;
     }
-    return child;
+    return _resolvedImage;
   }
 
   Widget _errorBuilder(context, error, stacktrace) {
@@ -451,6 +455,8 @@ class _OctoImageState extends State<OctoImage> {
   }
 
   Widget _placeholder(BuildContext context) {
+    if(_previousImage != null) return _previousImage;
+
     if (widget.placeholderBuilder != null) {
       return Center(child: widget.placeholderBuilder(context));
     }
@@ -461,8 +467,7 @@ class _OctoImageState extends State<OctoImage> {
     assert(widget.placeholderBuilder == null ||
         widget.progressIndicatorBuilder == null);
 
-    if (_isImageResolved) return _PlaceholderType.none;
-
+    if (_previousImage != null) return _PlaceholderType.static;
     if (widget.placeholderBuilder != null) return _PlaceholderType.static;
     if (widget.progressIndicatorBuilder != null) {
       return _PlaceholderType.progress;


### PR DESCRIPTION
fixes #4

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
feature and bug fix

### :arrow_heading_down: What is the current behavior?
Currently gapless playback just goes from one image to the other in 1 frame.

### :new: What is the new behavior (if this is a feature change)?
The new gapless playback fades from one image to the next the same way as from a placeholder.
Also it keeps the image transformations that was applied on the previous image.

### :boom: Does this PR introduce a breaking change?
Not really

### :bug: Recommendations for testing
With this app you can easily test the gapless playback feature:
```
void main() {
  runApp(MyApp());
}

class MyApp extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      title: 'OctoImage Demo',
      theme: ThemeData(),
      home: HomePage(),
    );
  }
}

class HomePage extends StatefulWidget {
  @override
  _HomePageState createState() => _HomePageState();
}

class _HomePageState extends State<HomePage> {
  int count = 1;
  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(
        title: Text("Gapless"),
      ),
      body: Center(
        child: OctoImage(
          gaplessPlayback: true,
        fadeInDuration: Duration.zero,
        placeholderBuilder: (context) => Center(child: CircularProgressIndicator(),),
          image: CachedNetworkImageProvider(
              'https://via.placeholder.com/${count}00'),
        ),
      ),
      floatingActionButton: FloatingActionButton(
        onPressed: () => setState(() => count++),
      ),
    );
  }
}
```

### :memo: Links to relevant issues/docs
#4 

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines 
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
