### PR TITLE
Width and height on image doesn't restrain widgets

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,1 @@
-include: package:effective_dart/analysis_options.yaml
+include: package:pedantic/analysis_options.1.8.0.yaml

--- a/lib/src/image.dart
+++ b/lib/src/image.dart
@@ -333,21 +333,26 @@ class _OctoImageState extends State<OctoImage> {
         break;
     }
 
-    return Image(
-      image: widget.image,
-      loadingBuilder:
-          placeholderType == _PlaceholderType.progress ? _loadingBuilder : null,
-      frameBuilder: frameBuilder,
-      errorBuilder: widget.errorBuilder != null ? _errorBuilder : null,
-      fit: widget.fit,
+    return SizedBox(
       width: widget.width,
       height: widget.height,
-      alignment: widget.alignment,
-      repeat: widget.repeat,
-      color: widget.color,
-      colorBlendMode: widget.colorBlendMode,
-      matchTextDirection: widget.matchTextDirection,
-      filterQuality: widget.filterQuality,
+      child: Image(
+        image: widget.image,
+        loadingBuilder: placeholderType == _PlaceholderType.progress
+            ? _loadingBuilder
+            : null,
+        frameBuilder: frameBuilder,
+        errorBuilder: widget.errorBuilder != null ? _errorBuilder : null,
+        fit: widget.fit,
+        width: widget.width,
+        height: widget.height,
+        alignment: widget.alignment,
+        repeat: widget.repeat,
+        color: widget.color,
+        colorBlendMode: widget.colorBlendMode,
+        matchTextDirection: widget.matchTextDirection,
+        filterQuality: widget.filterQuality,
+      ),
     );
   }
 


### PR DESCRIPTION
SizedBox around the Image makes sure all provided builders are within the provided height and width

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)


### :arrow_heading_down: What is the current behavior?
Placeholder and error widgets were not bounded by width and height of the image

### :new: What is the new behavior (if this is a feature change)?
Now the whole widget is bound by the width and height given.

### :boom: Does this PR introduce a breaking change?
Only for people who want their placeholder and error widgets to be larger than the image itself.

### :bug: Recommendations for testing
Easy to test with the frame placeholder, which always takes the maximum size.
Previously this placeholder showed full-screen, now it is bound to 150x150:

```
class TestImage extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(
        title: Text('OctoImage Demo'),
      ),
      body: Center(
        child: OctoImage(
          image: CachedNetworkImageProvider('https://via.placeholder.com/150'),
          placeholderBuilder: OctoPlaceholder.frame(),
          width: 150,
          height: 150,,
        ),
      ),
    );
  }
}
```

### :memo: Links to relevant issues/docs
Fixes #7 

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines 
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
