### PR TITLE
OctoError.blurHash dynamic icon, color and size

### DIFF
--- a/lib/src/errors.dart
+++ b/lib/src/errors.dart
@@ -11,10 +11,20 @@ import '../octo_image.dart';
 ///    );
 class OctoError {
   /// Show [OctoPlaceholder.blurHash] with an error icon on top.
-  static OctoErrorBuilder blurHash(String hash, {BoxFit fit, Text message}) {
+  static OctoErrorBuilder blurHash(
+    String hash, {
+    BoxFit fit,
+    Text message,
+    IconData icon,
+    Color iconColor,
+    double iconSize,
+  }) {
     return placeholderWithErrorIcon(
       OctoPlaceholder.blurHash(hash, fit: fit),
       message: message,
+      icon: icon,
+      iconColor: iconColor,
+      iconSize: iconSize,
     );
   }
 
@@ -49,9 +59,13 @@ class OctoError {
   static OctoErrorBuilder placeholderWithErrorIcon(
     OctoPlaceholderBuilder placeholderBuilder, {
     IconData icon,
+    Color iconColor,
+    double iconSize,
     Text message,
   }) {
     icon ??= Icons.error_outline;
+    iconColor ??= Colors.black;
+    iconSize ??= 30.0;
     return (context, error, stacktrace) => Stack(
           alignment: Alignment.center,
           children: [
@@ -60,7 +74,8 @@ class OctoError {
                 opacity: 0.75,
                 child: Icon(
                   icon,
-                  size: 30,
+                  size: iconSize,
+                  color: iconColor,
                 )),
             if (message != null)
               Align(

--- a/lib/src/errors.dart
+++ b/lib/src/errors.dart
@@ -11,6 +11,8 @@ import '../octo_image.dart';
 ///    );
 class OctoError {
   /// Show [OctoPlaceholder.blurHash] with an error icon on top.
+  /// Error icon can be modified along with its size and color.
+  /// By default icon color will be the value given by the current [IconTheme].
   static OctoErrorBuilder blurHash(
     String hash, {
     BoxFit fit,
@@ -64,7 +66,6 @@ class OctoError {
     Text message,
   }) {
     icon ??= Icons.error_outline;
-    iconColor ??= Colors.black;
     iconSize ??= 30.0;
     return (context, error, stacktrace) => Stack(
           alignment: Alignment.center,


### PR DESCRIPTION
### :sparkles: User can change iconData, iconColor and iconSize when using OctoError.blurHash() as errorBuilder.


### :arrow_heading_down: Icon and its properties cannot be changed.


### :new: IconData, IconColor and IconSize can be changed.


### :boom: no


### :bug: no


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines 
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop
