### PR TITLE
removed Center around error and placeholder

### DIFF
--- a/lib/src/image.dart
+++ b/lib/src/image.dart
@@ -448,22 +448,19 @@ class _OctoImageState extends State<OctoImage> {
   }
 
   Widget _errorBuilder(context, error, stacktrace) {
-    return Center(
-      child: widget.errorBuilder(context, error, stacktrace),
-    );
+    return widget.errorBuilder(context, error, stacktrace);
   }
 
   Widget _progressIndicator(
       BuildContext context, ImageChunkEvent loadingProgress) {
-    return Center(
-        child: widget.progressIndicatorBuilder(context, loadingProgress));
+    return widget.progressIndicatorBuilder(context, loadingProgress);
   }
 
   Widget _placeholder(BuildContext context) {
     if (_previousImage != null) return _previousImage;
 
     if (widget.placeholderBuilder != null) {
-      return Center(child: widget.placeholderBuilder(context));
+      return widget.placeholderBuilder(context);
     }
     return Container();
   }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bugfix 

### :arrow_heading_down: What is the current behavior?
Currently the error and placeholder widgets are always centered. This breaks the fit properties of these widgets.

### :new: What is the new behavior (if this is a feature change)?
The Center widget is removed. Not sure why that was ever there.

### :boom: Does this PR introduce a breaking change?
Yes, the behaviour of the error and placeholder widgets change.

### :bug: Recommendations for testing
I tested with the example from issue #11. I could not find any strange behaviour afterward.

### :memo: Links to relevant issues/docs
Fixes #11 

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines 
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
