### PR TITLE
When loadingProgress is null, progressIndicatorBuilder should not be called

### DIFF
--- a/lib/src/image.dart
+++ b/lib/src/image.dart
@@ -417,6 +417,9 @@ class _OctoImageState extends State<OctoImage> {
 
   Widget _loadingBuilder(
       BuildContext context, Widget child, ImageChunkEvent loadingProgress) {
+    if(loadingProgress == null) {
+      return SizedBox();
+    }
     if (_isLoaded) {
       if (_wasSynchronouslyLoaded) {
         return _image(context, child);


### PR DESCRIPTION
When loadingProgress is null, progressIndicatorBuilder should not be called

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix.

### :arrow_heading_down: What is the current behavior?
When loadingProgress is null, progressIndicatorBuilder will be called

### :new: What is the new behavior (if this is a feature change)?
When loadingProgress is null, progressIndicatorBuilder should not be called

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines 
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop
