### PR TITLE
Animate already loaded images when using gappless playback

### DIFF
--- a/lib/src/image/fade_widget.dart
+++ b/lib/src/image/fade_widget.dart
@@ -74,6 +74,7 @@ class _FadeWidgetState extends State<FadeWidget>
   @override
   void didUpdateWidget(FadeWidget oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if(Widget.canUpdate(oldWidget.child, widget.child)) return;
     opacity.removeStatusListener(animationStatusChange);
     controller.duration = widget.duration;
     controller.value = 0;

--- a/lib/src/image/fade_widget.dart
+++ b/lib/src/image/fade_widget.dart
@@ -72,6 +72,25 @@ class _FadeWidgetState extends State<FadeWidget>
   }
 
   @override
+  void didUpdateWidget(FadeWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    opacity.removeStatusListener(animationStatusChange);
+    controller.duration = widget.duration;
+    controller.value = 0;
+    final curved = CurvedAnimation(parent: controller, curve: widget.curve);
+    var begin = widget.direction == AnimationDirection.forward ? 0.0 : 1.0;
+    var end = widget.direction == AnimationDirection.forward ? 1.0 : 0.0;
+    opacity = Tween<double>(begin: begin, end: end).animate(curved);
+    controller.forward();
+
+    hideWidget = false;
+    if (widget.direction == AnimationDirection.reverse) {
+      opacity.addStatusListener(animationStatusChange);
+    }
+  }
+
+
+  @override
   void dispose() {
     opacity.removeStatusListener(animationStatusChange);
     controller.dispose();

--- a/lib/src/image/image.dart
+++ b/lib/src/image/image.dart
@@ -321,6 +321,7 @@ class _OctoImageState extends State<OctoImage> {
       colorBlendMode: widget.colorBlendMode,
       matchTextDirection: widget.matchTextDirection,
       filterQuality: widget.filterQuality,
+      alwaysShowPlaceHolder: false,
     );
   }
 
@@ -330,6 +331,9 @@ class _OctoImageState extends State<OctoImage> {
     if (oldWidget.image != widget.image) {
       if (widget.gaplessPlayback) {
         _previousHandler = _imageHandler;
+        _previousHandler?.alwaysShowPlaceHolder = false;
+      } else {
+        _previousHandler = null;
       }
     }
     _imageHandler = ImageHandler(
@@ -355,6 +359,7 @@ class _OctoImageState extends State<OctoImage> {
       colorBlendMode: widget.colorBlendMode,
       matchTextDirection: widget.matchTextDirection,
       filterQuality: widget.filterQuality,
+      alwaysShowPlaceHolder: _previousHandler != null,
     );
   }
 

--- a/lib/src/image/image_handler.dart
+++ b/lib/src/image/image_handler.dart
@@ -128,6 +128,10 @@ class ImageHandler {
   /// The curve of the fade-in animation for the [imageUrl].
   final Curve fadeInCurve;
 
+  /// Indicates that placeholder should always be shown, even if the image
+  /// was loaded in the first frame.
+  bool alwaysShowPlaceHolder;
+
   ImageHandler({
     required this.image,
     required this.width,
@@ -148,6 +152,7 @@ class ImageHandler {
     required this.fadeOutCurve,
     required this.fadeInDuration,
     required this.fadeInCurve,
+    required this.alwaysShowPlaceHolder,
   }) {
     _placeholderType = _definePlaceholderType();
   }
@@ -232,7 +237,7 @@ class ImageHandler {
         return _placeholder(context);
       }
     }
-    if (wasSynchronouslyLoaded) {
+    if (wasSynchronouslyLoaded && !alwaysShowPlaceHolder) {
       return _image(context, child);
     }
     return _stack(

--- a/lib/src/image/image_handler.dart
+++ b/lib/src/image/image_handler.dart
@@ -180,6 +180,7 @@ class ImageHandler {
 
   Widget build(BuildContext context) {
     return Image(
+      key: ValueKey(image),
       image: image,
       loadingBuilder: imageLoadingBuilder(),
       frameBuilder: imageFrameBuilder(),


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
The image widget doesn't show the placeholder when the image is already loaded in memory.

### :new: What is the new behavior (if this is a feature change)?
The image widget does show the placeholder when the image is already loaded, but the placeholder is the previous image and gapless playback is enabled.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Test in real life situations

### :memo: Links to relevant issues/docs
Fixes baseflow/flutter_cached_network_image#625

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines 
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
