### PR TITLE
Update links for pub.dev

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,8 @@
 name: octo_image
 description: A multifunctional Flutter image widget. Supports placeholders, error widgets and image transformers with fading.
 version: 1.0.2
-homepage: https://github.com/Baseflow/octo_image
+repository: https://github.com/Baseflow/octo_image
+issue_tracker: https://github.com/Baseflow/octo_image/issues
 
 environment:
   sdk: '>=2.12.0 <3.0.0'


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

With this PR, the right section on pub.dev will show the View/report issues link to GitHub again, like [here](https://pub.dev/packages/android_id) (the show-logic was recently changed).


### :arrow_heading_down: What is the current behavior?

It shows a `Homepage` link


### :new: What is the new behavior (if this is a feature change)?

It shows links to `Repository (GitHub)` and `View/report issues`


### :boom: Does this PR introduce a breaking change?

No.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [x] Follows style guide lines 
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
