### PR TITLE
Removed blurhash dependency

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,8 +35,8 @@ jobs:
         working-directory: ${{env.source-directory}}
 
       # Run Flutter Format to ensure formatting is valid
-      - name: Run Flutter Format
-        run: flutter format --set-exit-if-changed .
+      - name: Run Dart Format
+        run: dart format --set-exit-if-changed .
         working-directory: ${{env.source-directory}}
 
   analyze:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [2.0.0] - 2023-09-25
+* Remove Blurhash dependency, see [in the readme](https://pub.dev/packages/octo_image#blurhash) how to keep using blurhash.
+
 ## [1.0.2] - 2022-05-16
 * Update Blurhash dependency
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ You can use them with OctoImage.fromSet:
 ```dart
 OctoImage.fromSet(
   image: image,
-  octoSet: OctoSet.blurHash('LEHV6nWB2yk8pyo0adR*.7kCMdnj'),
+  octoSet: OctoSet.circleAvatar(backgroundColor: Colors.red, text: Text("M")),
 ),
 ```
 
@@ -178,9 +178,52 @@ All included OctoSets are:
 
 |**OctoSet**|**Explanation**|
 |---|---|
-|blurHash|Shows a blurhash as placeholder and error widget. When an error is thrown an icon is shown on top.|
 |circleAvatar|Shows a colored circle with text during load and error. Clips the image after successful load.|
 |circularIndicatorAndIcon|Shows a circularProgressIndicator with or without progress and an icon on error.|
+
+### Blurhash
+You can easily create your own OctoSet though, for example if you want to use blurHash as a placeholder:
+```dart
+/// Simple set to show [OctoPlaceholder.circularProgressIndicator] as
+/// placeholder and [OctoError.icon] as error.
+OctoSet blurHash(
+  String hash, {
+  BoxFit? fit,
+  Text? errorMessage,
+}) {
+  return OctoSet(
+    placeholderBuilder: blurHashPlaceholderBuilder(hash, fit: fit),
+    errorBuilder: blurHashErrorBuilder(hash, fit: fit),
+  );
+}
+
+OctoPlaceholderBuilder blurHashPlaceholderBuilder(String hash, {BoxFit? fit}) {
+  return (context) => SizedBox.expand(
+    child: Image(
+      image: BlurHashImage(hash),
+      fit: fit ?? BoxFit.cover,
+    ),
+  );
+}
+
+
+OctoErrorBuilder blurHashErrorBuilder(
+  String hash, {
+  BoxFit? fit,
+  Text? message,
+  IconData? icon,
+  Color? iconColor,
+  double? iconSize,
+}) {
+  return OctoError.placeholderWithErrorIcon(
+    blurHashPlaceholderBuilder(hash, fit: fit),
+    message: message,
+    icon: icon,
+    iconColor: iconColor,
+    iconSize: iconSize,
+  );
+}
+```
 
 # Contribute
 

--- a/example/lib/helpers/mock_image_provider.dart
+++ b/example/lib/helpers/mock_image_provider.dart
@@ -1,6 +1,6 @@
-import 'dart:async' show Future, StreamController;
-import 'dart:typed_data';
+import 'dart:async';
 import 'dart:ui' as ui show Codec;
+import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
 
 import 'package:flutter/foundation.dart';
@@ -33,7 +33,8 @@ class MockImageProvider extends ImageProvider<MockImageProvider> {
   }
 
   @override
-  ImageStreamCompleter load(MockImageProvider key, DecoderCallback decode) {
+  ImageStreamCompleter loadImage(
+      MockImageProvider key, ImageDecoderCallback decode) {
     final chunkEvents = StreamController<ImageChunkEvent>();
     return MultiFrameImageStreamCompleter(
       codec: _loadAsync(key, chunkEvents, decode).first,
@@ -45,7 +46,7 @@ class MockImageProvider extends ImageProvider<MockImageProvider> {
   Stream<ui.Codec> _loadAsync(
     MockImageProvider key,
     StreamController<ImageChunkEvent> chunkEvents,
-    DecoderCallback decode,
+    ImageDecoderCallback decode,
   ) async* {
     try {
       if (showLoading) {
@@ -62,7 +63,8 @@ class MockImageProvider extends ImageProvider<MockImageProvider> {
       var url = 'https://blurha.sh/assets/images/img1.jpg';
       Uint8List imageBytes;
       imageBytes = (await http.get(Uri.parse(url))).bodyBytes;
-      var decodedImage = await decode(imageBytes);
+      final buffer = await ImmutableBuffer.fromUint8List(imageBytes);
+      var decodedImage = await decode(buffer);
       yield decodedImage;
     } finally {
       await chunkEvents.close();

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -31,8 +31,6 @@ class OctoImagePage extends StatelessWidget {
         children: [
           _customImage(),
           const SizedBox(height: 16),
-          _simpleBlur(),
-          const SizedBox(height: 16),
           _circleAvatar(),
         ],
       ),
@@ -53,20 +51,6 @@ class OctoImagePage extends StatelessWidget {
           return CircularProgressIndicator(value: value);
         },
         errorBuilder: (context, error, stacktrace) => const Icon(Icons.error),
-      ),
-    );
-  }
-
-  Widget _simpleBlur() {
-    return AspectRatio(
-      aspectRatio: 269 / 173,
-      child: OctoImage(
-        image: const NetworkImage('https://blurha.sh/assets/images/img1.jpg'),
-        placeholderBuilder: OctoPlaceholder.blurHash(
-          'LEHV6nWB2yk8pyo0adR*.7kCMdnj',
-        ),
-        errorBuilder: OctoError.icon(color: Colors.red),
-        fit: BoxFit.cover,
       ),
     );
   }

--- a/example/lib/main_sets.dart
+++ b/example/lib/main_sets.dart
@@ -16,7 +16,6 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(),
       home: OctoImagePage(
         sets: <OctoSet>[
-          OctoSet.blurHash('LEHV6nWB2yk8pyo0adR*.7kCMdnj'),
           OctoSet.circleAvatar(
             backgroundColor: Colors.red,
             text: const Text(

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,51 +5,58 @@ packages:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.8.2"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
-      url: "https://pub.dartlang.org"
+      sha256: fb98c0f6d12c920a02ee2d998da788bca066ca5f148492b7085ee23372b12306
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.18.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -59,7 +66,8 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      url: "https://pub.dartlang.org"
+      sha256: b543301ad291598523947dc534aaddc5aaad597b709d2426d3a0e0d44c5cb493
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
   flutter_test:
@@ -71,58 +79,65 @@ packages:
     dependency: "direct main"
     description:
       name: http
-      url: "https://pub.dartlang.org"
+      sha256: "2ed163531e071c2c6b7c659635112f24cb64ecbebf6af46b550d536c0b1aa112"
+      url: "https://pub.dev"
     source: hosted
     version: "0.13.4"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      url: "https://pub.dartlang.org"
+      sha256: e362d639ba3bc07d5a71faebb98cde68c05bfbcfbbb444b60b6f60bb67719185
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
   lints:
     dependency: transitive
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: a2c3d198cb5ea2e179926622d433331d8b58374ab8f29cdda6e863bd62fd369c
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.3"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      url: "https://pub.dev"
     source: hosted
-    version: "1.7.0"
+    version: "1.10.0"
   octo_image:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "1.0.2"
+    version: "2.0.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -132,57 +147,73 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.8"
+    version: "0.6.1"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.dartlang.org"
+      sha256: "53bdf7e979cfbf3e28987552fd72f637e63f3c8724c9e56d9246942dc2fa36ee"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "14f1f70c51119012600c5f1f60ca68efda5a9b6077748163c6af2893ec5df8fc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1-beta"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=3.2.0-157.0.dev <4.0.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -55,13 +55,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_blurhash:
-    dependency: transitive
-    description:
-      name: flutter_blurhash
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.7.0"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -122,7 +115,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.1"
+    version: "1.0.2"
   path:
     dependency: transitive
     description:
@@ -192,4 +185,4 @@ packages:
     source: hosted
     version: "2.1.1"
 sdks:
-  dart: ">=2.15.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"

--- a/lib/src/errors.dart
+++ b/lib/src/errors.dart
@@ -10,26 +10,6 @@ import '../octo_image.dart';
 ///      errorBuilder: OctoError.icon(),
 ///    );
 class OctoError {
-  /// Show [OctoPlaceholder.blurHash] with an error icon on top.
-  /// Error icon can be modified along with its size and color.
-  /// By default icon color will be the value given by the current [IconTheme].
-  static OctoErrorBuilder blurHash(
-    String hash, {
-    BoxFit? fit,
-    Text? message,
-    IconData? icon,
-    Color? iconColor,
-    double? iconSize,
-  }) {
-    return placeholderWithErrorIcon(
-      OctoPlaceholder.blurHash(hash, fit: fit),
-      message: message,
-      icon: icon,
-      iconColor: iconColor,
-      iconSize: iconSize,
-    );
-  }
-
   /// Displays a [CircleAvatar] as errorWidget
   static OctoErrorBuilder circleAvatar({
     required Color backgroundColor,

--- a/lib/src/octo_set.dart
+++ b/lib/src/octo_set.dart
@@ -25,7 +25,7 @@ class OctoSet {
   /// Widget displayed while the target [imageUrl] failed loading.
   final OctoErrorBuilder? errorBuilder;
 
-  OctoSet._({
+  OctoSet({
     this.imageBuilder,
     this.placeholderBuilder,
     this.progressIndicatorBuilder,
@@ -34,41 +34,25 @@ class OctoSet {
 
   /// Simple set to show [OctoPlaceholder.circularProgressIndicator] as
   /// placeholder and [OctoError.icon] as error.
-  factory OctoSet.blurHash(
-    String hash, {
-    BoxFit? fit,
-    Text? errorMessage,
-  }) {
-    return OctoSet._(
-      placeholderBuilder: OctoPlaceholder.blurHash(hash, fit: fit),
-      errorBuilder: OctoError.blurHash(hash, fit: fit),
-    );
-  }
-
-  /// Simple set to show [OctoPlaceholder.circularProgressIndicator] as
-  /// placeholder and [OctoError.icon] as error.
   factory OctoSet.circleAvatar({
     required Color backgroundColor,
     required Widget text,
   }) {
-    return OctoSet._(
-      placeholderBuilder: OctoPlaceholder.circleAvatar(
-          backgroundColor: backgroundColor, text: text),
+    return OctoSet(
+      placeholderBuilder:
+          OctoPlaceholder.circleAvatar(backgroundColor: backgroundColor, text: text),
       imageBuilder: OctoImageTransformer.circleAvatar(),
-      errorBuilder:
-          OctoError.circleAvatar(backgroundColor: backgroundColor, text: text),
+      errorBuilder: OctoError.circleAvatar(backgroundColor: backgroundColor, text: text),
     );
   }
 
   /// Simple set to show [OctoPlaceholder.circularProgressIndicator] as
   /// placeholder and [OctoError.icon] as error.
   factory OctoSet.circularIndicatorAndIcon({bool showProgress = false}) {
-    return OctoSet._(
-      placeholderBuilder:
-          showProgress ? null : OctoPlaceholder.circularProgressIndicator(),
-      progressIndicatorBuilder: showProgress
-          ? OctoProgressIndicator.circularProgressIndicator()
-          : null,
+    return OctoSet(
+      placeholderBuilder: showProgress ? null : OctoPlaceholder.circularProgressIndicator(),
+      progressIndicatorBuilder:
+          showProgress ? OctoProgressIndicator.circularProgressIndicator() : null,
       errorBuilder: OctoError.icon(),
     );
   }

--- a/lib/src/octo_set.dart
+++ b/lib/src/octo_set.dart
@@ -39,10 +39,11 @@ class OctoSet {
     required Widget text,
   }) {
     return OctoSet(
-      placeholderBuilder:
-          OctoPlaceholder.circleAvatar(backgroundColor: backgroundColor, text: text),
+      placeholderBuilder: OctoPlaceholder.circleAvatar(
+          backgroundColor: backgroundColor, text: text),
       imageBuilder: OctoImageTransformer.circleAvatar(),
-      errorBuilder: OctoError.circleAvatar(backgroundColor: backgroundColor, text: text),
+      errorBuilder:
+          OctoError.circleAvatar(backgroundColor: backgroundColor, text: text),
     );
   }
 
@@ -50,9 +51,11 @@ class OctoSet {
   /// placeholder and [OctoError.icon] as error.
   factory OctoSet.circularIndicatorAndIcon({bool showProgress = false}) {
     return OctoSet(
-      placeholderBuilder: showProgress ? null : OctoPlaceholder.circularProgressIndicator(),
-      progressIndicatorBuilder:
-          showProgress ? OctoProgressIndicator.circularProgressIndicator() : null,
+      placeholderBuilder:
+          showProgress ? null : OctoPlaceholder.circularProgressIndicator(),
+      progressIndicatorBuilder: showProgress
+          ? OctoProgressIndicator.circularProgressIndicator()
+          : null,
       errorBuilder: OctoError.icon(),
     );
   }

--- a/lib/src/placeholders.dart
+++ b/lib/src/placeholders.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_blurhash/flutter_blurhash.dart';
 
 import '../octo_image.dart';
 
@@ -10,18 +9,6 @@ import '../octo_image.dart';
 ///      placeholderBuilder: OctoPlaceholder.circularProgressIndicator(),
 ///    );
 class OctoPlaceholder {
-  /// Use [BlurHash](https://pub.dev/packages/flutter_blurhash) as a placeholder.
-  /// The hash should be made server side. See [blurha.sh](https://blurha.sh/) for more information.
-  /// [fit] defaults to [BoxFit.cover].
-  static OctoPlaceholderBuilder blurHash(String hash, {BoxFit? fit}) {
-    return (context) => SizedBox.expand(
-          child: Image(
-            image: BlurHashImage(hash),
-            fit: fit ?? BoxFit.cover,
-          ),
-        );
-  }
-
   /// Displays a [CircleAvatar] as placeholder
   static OctoPlaceholderBuilder circleAvatar({
     required Color backgroundColor,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -55,13 +55,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_blurhash:
-    dependency: "direct main"
-    description:
-      name: flutter_blurhash
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.7.0"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -171,4 +164,4 @@ packages:
     source: hosted
     version: "2.1.1"
 sdks:
-  dart: ">=2.15.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,51 +5,50 @@ packages:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.8.2"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.18.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -59,7 +58,8 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      url: "https://pub.dartlang.org"
+      sha256: b543301ad291598523947dc534aaddc5aaad597b709d2426d3a0e0d44c5cb493
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
   flutter_test:
@@ -71,37 +71,42 @@ packages:
     dependency: transitive
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: a2c3d198cb5ea2e179926622d433331d8b58374ab8f29cdda6e863bd62fd369c
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.3"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      url: "https://pub.dev"
     source: hosted
-    version: "1.7.0"
+    version: "1.10.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -111,57 +116,65 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.8"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.6.1"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "14f1f70c51119012600c5f1f60ca68efda5a9b6077748163c6af2893ec5df8fc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1-beta"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=3.2.0-157.0.dev <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,6 +5,7 @@ homepage: https://github.com/Baseflow/octo_image
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
+  flutter: '>=3.7.0'
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: octo_image
 description: A multifunctional Flutter image widget. Supports placeholders, error widgets and image transformers with fading.
-version: 1.0.2
+version: 2.0.0
 homepage: https://github.com/Baseflow/octo_image
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_blurhash: '>=0.6.0 <0.8.0' 
 
 dev_dependencies:
   flutter_test:

--- a/test/helpers/mock_image_provider.dart
+++ b/test/helpers/mock_image_provider.dart
@@ -1,5 +1,6 @@
 import 'dart:async' show Future, StreamController;
 import 'dart:ui' as ui show Codec;
+import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -33,7 +34,8 @@ class MockImageProvider extends ImageProvider<MockImageProvider> {
   }
 
   @override
-  ImageStreamCompleter load(MockImageProvider key, DecoderCallback decode) {
+  ImageStreamCompleter loadImage(
+      MockImageProvider key, ImageDecoderCallback decode) {
     final chunkEvents = StreamController<ImageChunkEvent>();
     return MultiFrameImageStreamCompleter(
       codec: _loadAsync(key, chunkEvents, decode).first,
@@ -45,7 +47,7 @@ class MockImageProvider extends ImageProvider<MockImageProvider> {
   Stream<ui.Codec> _loadAsync(
     MockImageProvider key,
     StreamController<ImageChunkEvent> chunkEvents,
-    DecoderCallback decode,
+    ImageDecoderCallback decode,
   ) async* {
     try {
       if (showLoading) {
@@ -58,7 +60,8 @@ class MockImageProvider extends ImageProvider<MockImageProvider> {
       if (fail) {
         throw Exception('Image loading failed');
       }
-      var decodedImage = await decode(kTransparentImage);
+      final buffer = await ImmutableBuffer.fromUint8List(kTransparentImage);
+      var decodedImage = await decode(buffer);
       yield decodedImage;
     } finally {
       await chunkEvents.close();

--- a/test/templates_test.dart
+++ b/test/templates_test.dart
@@ -3,7 +3,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:octo_image/octo_image.dart';
 
 List<OctoPlaceholderBuilder> placeholderBuilders = [
-  OctoPlaceholder.blurHash('LEHV6nWB2yk8pyo0adR*.7kCMdnj'),
   OctoPlaceholder.circularProgressIndicator(),
   OctoPlaceholder.circleAvatar(
     backgroundColor: Colors.blue,


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
This removes the blur_hash OctoSet

### :arrow_heading_down: What is the current behavior?
Currently it's depending on blur_hash and blur_hash is broken on current master channel, see https://github.com/fluttercommunity/flutter_blurhash/issues/57
As OctoImage is also used by other packages, such as CachedNetworkImage this also breaks those packages.

### :new: What is the new behavior (if this is a feature change)?
It removes the dependency on blur_hash and adds an explanation to the readme how to keep using it.
I would say that no included OctoSet should ever add external dependencies to keep this package clean and maintainable.

### :boom: Does this PR introduce a breaking change?
Yes, because we are removing an existing API.

### :bug: Recommendations for testing
No recommendations, as we only remove some non-critical code.

### :memo: Links to relevant issues/docs
https://github.com/Baseflow/octo_image/issues/29

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
