### PR TITLE
fix(issue-34): dispose child when duration is zero

### DIFF
--- a/lib/src/image/fade_widget.dart
+++ b/lib/src/image/fade_widget.dart
@@ -67,7 +67,11 @@ class _FadeWidgetState extends State<FadeWidget>
 
     hideWidget = false;
     if (widget.direction == AnimationDirection.reverse) {
-      opacity.addStatusListener(animationStatusChange);
+      if (widget.duration == Duration.zero) {
+        hideWidget = true;
+      } else {
+        opacity.addStatusListener(animationStatusChange);
+      }
     }
   }
 

--- a/lib/src/image/fade_widget.dart
+++ b/lib/src/image/fade_widget.dart
@@ -90,7 +90,11 @@ class _FadeWidgetState extends State<FadeWidget>
 
     hideWidget = false;
     if (widget.direction == AnimationDirection.reverse) {
-      opacity.addStatusListener(animationStatusChange);
+      if (widget.duration == Duration.zero) {
+        hideWidget = true;
+      } else {
+        opacity.addStatusListener(animationStatusChange);
+      }
     }
   }
 


### PR DESCRIPTION
### :sparkles: fix issue #34 


### :arrow_heading_down: What is the current behavior?

The child is not getting disposed due to animation controller not giving callbacks when the duration is zero


### :new: What is the new behavior (if this is a feature change)?

set the hide widget to true explicity when the direction is reverse and duration is zero


### :boom: Does this PR introduce a breaking change?

NO


### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs

#34 
https://github.com/Baseflow/flutter_cached_network_image/issues/942


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
