### PR TITLE
fix: :bug: prevent unnecessary image handler updates

### DIFF
--- a/lib/src/image/image.dart
+++ b/lib/src/image/image.dart
@@ -326,14 +326,21 @@ class _OctoImageState extends State<OctoImage> {
   @override
   void didUpdateWidget(OctoImage oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.image != widget.image) {
-      if (widget.gaplessPlayback) {
-        _previousHandler = _imageHandler;
-        _previousHandler?.alwaysShowPlaceHolder = false;
-      } else {
-        _previousHandler = null;
-      }
+
+    final hasSameConfiguration =
+        // TODO: Remove this function once the ResizeImage equality issue is resolved.
+        // https://github.com/flutter/flutter/issues/172550
+        _isSameImageProvider(oldWidget.image, widget.image);
+
+    if (hasSameConfiguration) return;
+
+    if (widget.gaplessPlayback) {
+      _previousHandler = _imageHandler;
+      _previousHandler?.alwaysShowPlaceHolder = false;
+    } else {
+      _previousHandler = null;
     }
+
     _imageHandler = ImageHandler(
       image: widget.image,
       imageBuilder: widget.imageBuilder,
@@ -368,5 +375,14 @@ class _OctoImageState extends State<OctoImage> {
       height: widget.height,
       child: _imageHandler.build(context),
     );
+  }
+
+  bool _isSameImageProvider(ImageProvider a, ImageProvider b) {
+    if (a is ResizeImage && b is ResizeImage) {
+      return a.imageProvider == b.imageProvider &&
+          a.width == b.width &&
+          a.height == b.height;
+    }
+    return a == b;
   }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

- Bug fix


### :arrow_heading_down: What is the current behavior?

- The `ImageHandler` is updated even when the configuration has not changed (`image`, `memCacheHeight` and `memCacheWidth`). This results in unnecessary repaints, affecting performance.

### :new: What is the new behavior (if this is a feature change)?

- The `ImageHandler` now only updates when there's an actual change in configuration (`image`, `memCacheHeight` and `memCacheWidth`). This prevents unnecessary repaints and improves performance by ensuring the widget tree remains stable when no update is needed.

### :boom: Does this PR introduce a breaking change?

- No

### :bug: Recommendations for testing

- Image does not repaint when the widget rebuilds with the same parameters, including when `memCacheWidth` and `memCacheHeight` are provided.

### :memo: Links to relevant issues/docs

- Fixes #39 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop
